### PR TITLE
Prevent garbage collection of exported interface

### DIFF
--- a/src/aiodbus/interface/base.py
+++ b/src/aiodbus/interface/base.py
@@ -169,6 +169,7 @@ class DbusInterface(metaclass=DbusInterfaceMeta):
             interface_member_list.append(value)
 
         export_handle = DbusExportHandle()
+        export_handle.append(self) # add exported interface to avoid garbage collection while it is exported
         exported_interfaces = list[str]()
 
         for interface_name, member_list in interface_map.items():
@@ -206,3 +207,7 @@ class DbusInterface(metaclass=DbusInterfaceMeta):
         new_object = cls.__new__(cls)
         new_object._proxify(service_name, object_path, bus)
         return new_object
+
+    def close(self):
+        # Called when interface export ends
+        pass


### PR DESCRIPTION
If user didn't store reference to exported interface somewhere, it would be garbage collected