### PR TITLE
Fix current_message tracking

### DIFF
--- a/src/aiodbus/bus/message.py
+++ b/src/aiodbus/bus/message.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio.tasks
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Optional, Protocol
@@ -21,10 +22,9 @@ _current_message: ContextVar[DbusMessage] = ContextVar("current_message")
 @contextmanager
 def set_current_message(message: DbusMessage):
     token = _current_message.set(message)
-    try:
-        yield message
-    finally:
-        _current_message.reset(token)
+    yield message
+    # Using try..finally would result in task destroy runing finally and crashing on variable from different context.
+    _current_message.reset(token)
 
 
 def get_current_message() -> DbusMessage:

--- a/src/aiodbus/bus/sdbus.py
+++ b/src/aiodbus/bus/sdbus.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextvars
 import errno
 import logging
 from collections import defaultdict
@@ -97,8 +99,14 @@ class SdBusServingInterface(DbusInterfaceBuilder):
         result_signature: str, callback: MethodCallable, message: SdBusMessage
     ) -> None:
         try:
-            with set_current_message(message):
-                reply_data = await callback(*message.parse_to_tuple())
+
+            async def wrapped():
+                with set_current_message(message):
+                    await callback(*message.parse_to_tuple())
+
+            ctx = contextvars.copy_context()
+            task = asyncio.create_task(wrapped(), context=ctx)
+            reply_data = await task
 
             if not message.expect_reply:
                 return


### PR DESCRIPTION
- Run callback within a separate context
- Avoid unsetting current message when cleaning up task being destroyed.