### PR TITLE
Always specify method and property name when generating python dbus interfaces

### DIFF
--- a/src/aiodbus/generator.py
+++ b/src/aiodbus/generator.py
@@ -558,6 +558,7 @@ INTERFACE_TEMPLATES: Dict[str, str] = {
 """,
     "generic_method_flags": (
         """\
+name="{{ method.method_name }}",
 {% if method.dbus_input_signature %}
 input_signature="{{ method.dbus_input_signature }}",
 {% endif %}
@@ -574,6 +575,7 @@ result_args_names={{method.result_args_names_repr}},
     ),
     "generic_property_flags": (
         """\
+name="{{ a_property.method_name }}",
 {% if a_property.dbus_signature %}
 signature="{{ a_property.dbus_signature }}",
 {% endif %}


### PR DESCRIPTION
Some interfaces do not conform to PascalCase convention and would be broken when generated from dbus xml interface file.

For example the org.freedesktop.timedate1 has CanNTP and LocalRTC properties and SetNTP and SetLocalRTC methods, these would get translated to CanNtp, LocalRtc, SetNtp and SetLocalRtc when being called on dbus with the dbusify_name.

The conversion from xml names to python's snake case and then to the format that should be called on dbus is lossy in this way.

This makes it that when generating python interfaces from xml dbus interfaces we always include the original name in @dbus_method or @dbus_property.

The original behavior when 'name' on these decorators is not set is preserved, only the generated decorators explicitly specify the name as we have it easily available.